### PR TITLE
fix: remove orphaned </main> tag from meeting-1.md

### DIFF
--- a/docs/_meetings/meeting-1.md
+++ b/docs/_meetings/meeting-1.md
@@ -464,8 +464,6 @@ document.addEventListener('keydown', function(event) {
   </div>
 </div>
 
-  </main>
-
   <!-- Meeting Toolkit Sidebar -->
   <aside class="meeting-sidebar">
     <div class="sidebar-section">


### PR DESCRIPTION
Fixes #53 - removed orphaned closing </main> tag on line 467 that had no corresponding opening tag. The meeting layout uses <article> tags instead.

Generated with [Claude Code](https://claude.ai/code)