### PR TITLE
fix: remove extra spacing from meeting badge buttons on click

### DIFF
--- a/docs/_sass/base/_critical.scss
+++ b/docs/_sass/base/_critical.scss
@@ -1741,6 +1741,11 @@ a {
     &:hover {
       transform: translateY(-2px);
     }
+
+    &:active {
+      transform: translateY(0);
+      transition: none; // Instant feedback on click
+    }
   }
 
   .meeting-badge {


### PR DESCRIPTION
This PR fixes the extra margin/padding issue on meeting badge buttons when clicking.

## Changes
- Added `:active` state styling to `.meeting-link` elements
- Prevents visual glitches and spacing issues during click interactions
- Returns button to normal position with instant feedback

Closes #54

Generated with [Claude Code](https://claude.ai/code)